### PR TITLE
chore: drop `license-file` field value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 description = "アイデア投稿履歴のリアクションをサポートするDiscord Bot"
 authors = ["GiganticMinecraft"]
 license = "MIT"
-license-file = "LICENSE"
 repository = "https://github.com/GiganticMinecraft/idea-reaction"
 
 [dependencies]


### PR DESCRIPTION
警告解消: SPDXが振られているライセンスは`license`フィールドが好まれるため