### PR TITLE
build: Optimization of Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
-FROM rust:1.83.0-bullseye as Builder
+FROM rust:1.83.0-bookworm AS builder
 
 WORKDIR /root/app
 COPY --chown=root:root . .
 
 RUN cargo build --release --bin idea-reaction
 
-FROM debian:bullseye-slim as Runner
+FROM gcr.io/distroless/cc-debian12 AS runner
 
-COPY --from=Builder --chown=root:root /root/app/target/release/idea-reaction /usr/local/bin/idea-reaction
-
-RUN apt-get update && apt-get install -y libssl-dev ca-certificates
-
-RUN useradd --create-home --user-group idea-reaction
-USER idea-reaction
-WORKDIR /home/idea-reaction
+COPY --from=Builder --chown=root:root /root/app/target/release/idea-reaction /
 
 LABEL org.opencontainers.image.source=https://github.com/GiganticMinecraft/idea-reaction
 
-ENTRYPOINT [ "idea-reaction" ]
+ENTRYPOINT ["/idea-reaction"]

--- a/docker-redmine/compose.yaml
+++ b/docker-redmine/compose.yaml
@@ -2,7 +2,7 @@
 
 services:
   redmine:
-    image: redmine:6.0.2-bookworm
+    image: redmine:5.1.5
     ports:
       - 8080:3000
     environment:


### PR DESCRIPTION
- [ ] `gcr.io/distroless/cc-debian12` を採用したが， コメント投稿ができず，意図的に panic するよう仕向けると reqwest が `tcp connect error` を吐いているので保留 (libssl は入っているはず)

```
thread 'tokio-runtime-worker' panicked at src/redmine/actions.rs:48:13:
Failed to send request to Redmine: reqwest::Error { kind: Request, url: "http://localhost:8080/issues/3.json?key=***", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) }
```